### PR TITLE
fix multi-language site urls

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,8 +10,14 @@ module.exports = {
         // Index page
         "page": function(page) {
             if (this.options.generator == 'website') {
+                // multiple languages, if configured
+                var lang = "";
+                if(this.context.config.language) {
+                    lang = this.context.config.language + "/";
+                }
+
                 urls.push({
-                    url: this.contentPath(page.path)
+                    url: this.contentPath(lang + page.path)
                 });
             }
 


### PR DESCRIPTION
As mentioned in #2, the original sitemap plugin did not consider multiple languages site. I fixed it with var `lang`, test case passed in both multi-language and single language site.
