### PR TITLE
Fix bug in single language site

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,11 @@ module.exports = {
             if (this.options.generator == 'website') {
                 // multiple languages, if configured
                 var lang = this.isSubBook()? this.config.get('language') : null;
-                if (lang) lang = lang + '/';
+                if (lang) {
+                    lang = lang + '/';
+                } else {
+                    lang = '';
+                }
 
                 urls.push({
                     url: this.contentPath(lang + page.path)


### PR DESCRIPTION
In single language site, it generates urls like "http://xxx.com/nullREADME.html", should be "http://xxx.com/README.html"
