### PR TITLE
generate sitemap for each language

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var path = require('path');
 var url = require('url');
 var sm = require('sitemap');
 
-var urls = [];
+var urls = {'lang_all': []};
 
 module.exports = {
     hooks: {
@@ -11,10 +11,16 @@ module.exports = {
         "page": function(page) {
             if (this.output.name != 'website') return page;
 
-            var lang = this.isLanguageBook()? this.language : '';
+            var lang = this.isLanguageBook()? this.config.values.language : '';
+            var lang_index = lang || 'lang_all';
+            if (!urls[lang_index]) urls[lang_index] = [];
             if (lang) lang = lang + '/';
 
-            urls.push({
+            urls[lang_index].push({
+                url: this.output.toURL(lang + page.path)
+            });
+
+            urls['lang_all'].push({
                 url: this.output.toURL(lang + page.path)
             });
 
@@ -23,10 +29,12 @@ module.exports = {
 
         // Write sitemap.xml
         "finish": function() {
+            var lang = this.isLanguageBook()? this.config.values.language : '';
+            var lang_index = lang || 'lang_all';
             var sitemap = sm.createSitemap({
                 cacheTime: 600000,
                 hostname: url.resolve(this.config.get('pluginsConfig.sitemap.hostname'), '/'),
-                urls: urls
+                urls: urls[lang_index]
             });
 
             var xml = sitemap.toString();


### PR DESCRIPTION
This PR add sitemap for each language, e.g. it will generate sitemap for language `en` website under `en/sitemap.xml` and `zh-hans` website under `zh-hans/sitemap.xml`.

Since `urls` is defined as `[]` in previous implementation, `sitemap.xml` would include other language website. I replaced it with `{}`.
