### PR TITLE
Updating version of sitemap because of security risks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,42 @@
+{
+    "name": "gitbook-plugin-sitemap",
+    "version": "1.2.0",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "@types/node": {
+            "version": "15.14.9",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
+            "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A=="
+        },
+        "@types/sax": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.3.tgz",
+            "integrity": "sha512-+QSw6Tqvs/KQpZX8DvIl3hZSjNFLW/OqE5nlyHXtTwODaJvioN2rOWpBNEWZp2HZUFhOh+VohmJku/WxEXU2XA==",
+            "requires": {
+                "@types/node": "*"
+            }
+        },
+        "arg": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.1.tgz",
+            "integrity": "sha512-e0hDa9H2Z9AwFkk2qDlwhoMYE4eToKarchkQHovNdLTCYMHZHeRjI71crOh+dio4K6u1IcwubQqo79Ga4CyAQA=="
+        },
+        "sax": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+        },
+        "sitemap": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-7.0.0.tgz",
+            "integrity": "sha512-Ud0jrRQO2k7fEtPAM+cQkBKoMvxQyPKNXKDLn8tRVHxRCsdDQ2JZvw+aZ5IRYYQVAV9iGxEar6boTwZzev+x3g==",
+            "requires": {
+                "@types/node": "^15.0.1",
+                "@types/sax": "^1.2.1",
+                "arg": "^5.0.0",
+                "sax": "^1.2.4"
+            }
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -7,13 +7,15 @@
         "gitbook": ">=3.0.0-pre.0"
     },
     "homepage": "https://github.com/GitbookIO/plugin-sitemap",
-    "keywords": ["seo"],
+    "keywords": [
+        "seo"
+    ],
     "repository": {
         "type": "git",
         "url": "https://github.com/GitbookIO/plugin-sitemap.git"
     },
     "dependencies": {
-        "sitemap": "1.5.0"
+        "sitemap": "7.0.0"
     },
     "license": "Apache-2.0",
     "bugs": {


### PR DESCRIPTION
Sitemap in version 1.5.0 still using underscore in a version that is a security risk, so we should update for the latest version that now is 7.0.0 to avoid the security risk, for more information about you can check : https://nvd.nist.gov/vuln/detail/CVE-2021-23358 